### PR TITLE
Improve exception exercises, add double errored entry.

### DIFF
--- a/src/main/scala/fundamentals/level03/ExceptionExercises.scala
+++ b/src/main/scala/fundamentals/level03/ExceptionExercises.scala
@@ -19,6 +19,7 @@ object ExceptionExercises {
          ("The Professor", "200"),
          ("Berlin", "43"),
          ("Arturo Roman", "0"),
+         ("", "1000"), // <- Two errors should be dealt with
          ("", "30"))
 
 /**

--- a/src/test/scala/fundamentals/level03/ExceptionExercisesTest.scala
+++ b/src/test/scala/fundamentals/level03/ExceptionExercisesTest.scala
@@ -106,15 +106,23 @@ class ExceptionExercisesTest extends FunSpec with TypeCheckedTripleEquals {
 
   describe("collectErrors") {
 
+    def exceptionEq(e1: Exception, e2: Exception): Boolean =
+      e1.getClass == e2.getClass && e1.getMessage == e2.getMessage
+
+    val expectedErrors = List(
+      new InvalidAgeValueException("provided age is invalid: 5o"),
+      new InvalidAgeRangeException("provided age should be between 1-120: 200"),
+      new InvalidAgeRangeException("provided age should be between 1-120: 0"),
+      new EmptyNameException("provided name is empty"),
+      new InvalidAgeRangeException("provided age should be between 1-120: 1000"),
+      new EmptyNameException("provided name is empty")
+    )
+
+    it("should return all errors") {
+      collectErrors.size === 6
+    }
+
     it("should return a List Exceptions thrown while processing inputs") {
-
-      def exceptionEq(e1: Exception, e2: Exception): Boolean =
-        e1.getClass == e2.getClass && e1.getMessage == e2.getMessage
-
-      val expectedErrors = List(new InvalidAgeValueException("provided age is invalid: 5o"),
-                                    new InvalidAgeRangeException("provided age should be between 1-120: 200"),
-                                    new InvalidAgeRangeException("provided age should be between 1-120: 0"),
-                                    new EmptyNameException("provided name is empty"))
       collectErrors.zip(expectedErrors).foreach {
         case (e1, e2) => assert(exceptionEq(e1, e2), s"$e1 != $e2")
       }


### PR DESCRIPTION
- By adding a tuple with error in name and age makes `collectErrors` implementation more complicated.
- added extra test while trying to prove the case and found it useful to have as `zip` ignores values when list sizes are different.
