### PR TITLE
Add .map example to Try

### DIFF
--- a/src/main/scala/fundamentals/level03/TryExercises.scala
+++ b/src/main/scala/fundamentals/level03/TryExercises.scala
@@ -64,7 +64,7 @@ object TryExercises {
     * = Success(11)
     *
     * scala> increment("NaN")
-    * = Failure(TryError("NaN is not a valid number"))
+    * = Failure(java.lang.NumberFormatException: For input string: "NaN")
     *
     * Hint: Solve it without using pattern matching
     */

--- a/src/main/scala/fundamentals/level03/TryExercises.scala
+++ b/src/main/scala/fundamentals/level03/TryExercises.scala
@@ -49,10 +49,10 @@ object TryExercises {
 
   /**
     * scala> parseBooleanSafe("true")
-    * = Right(true)
+    * = Success(true)
     *
     * scala> parseBooleanSafe("abc")
-    * = Left(TryError("abc cannot be converted to Boolean"))
+    * = Failure(TryError("abc cannot be converted to Boolean"))
     *
     * Hint: Use .toBoolean to convert a String to a Boolean
     **/
@@ -61,10 +61,10 @@ object TryExercises {
 
   /**
     * scala> increment("10")
-    * = Right(11)
+    * = Success(11)
     *
     * scala> increment("NaN")
-    * = Left(TryError("NaN is not a valid number"))
+    * = Failure(TryError("NaN is not a valid number"))
     *
     * Hint: Solve it without using pattern matching
     */

--- a/src/main/scala/fundamentals/level03/TryExercises.scala
+++ b/src/main/scala/fundamentals/level03/TryExercises.scala
@@ -58,6 +58,19 @@ object TryExercises {
     **/
   def parseBooleanSafe(str: String): Try[Boolean] = ???
 
+
+  /**
+    * scala> increment("10")
+    * = Right(11)
+    *
+    * scala> increment("NaN")
+    * = Left(TryError("NaN is not a valid number"))
+    *
+    * Hint: Solve it without using pattern matching
+    */
+
+  def increment(str: String): Try[Int] = ???
+
   /**
     * Remember that `Try[A]` ~ `Either[Throwable, A]`
     *

--- a/src/test/scala/fundamentals/level03/TryExercisesTest.scala
+++ b/src/test/scala/fundamentals/level03/TryExercisesTest.scala
@@ -40,6 +40,17 @@ class TryExercisesTest extends FunSpec with TypeCheckedTripleEquals {
 
   }
 
+  describe("increment") {
+
+    it("should increment the given number") {
+      assert(increment("5") === Success(6))
+    }
+
+    it("should return error message given not a number") {
+      assert(increment("NaN").isFailure === true)
+    }
+  }
+
   describe("tryToEither") {
 
     it("should return Right given Success") {


### PR DESCRIPTION
As we have a for comprehension exercise, felt that we should introduce .map to Try before that. 

I thought of introducing 

```
  def intOperation(str: String, f: Int => Int): Try[Int] = ???
```

then thought it might be too difficult, what's your thought on that @wjlow @sanjivsahayamrea  