### PR TITLE
Remove needing to use trim. This simplifies the exercise.

### DIFF
--- a/src/main/scala/fundamentals/level03/ExceptionExercises.scala
+++ b/src/main/scala/fundamentals/level03/ExceptionExercises.scala
@@ -40,10 +40,7 @@ object ExceptionExercises {
     * scala> getName("")
     * = EmptyNameException: provided name is empty
     *
-    * scala> getName("   ")
-    * = EmptyNameException: provided name is empty
-    *
-    * Hint: use the trim and isEmpty methods on String
+    * Hint: use the isEmpty method on String
     */
   def getName(providedName: String) : String = ???
 

--- a/src/test/scala/fundamentals/level03/ExceptionExercisesTest.scala
+++ b/src/test/scala/fundamentals/level03/ExceptionExercisesTest.scala
@@ -20,13 +20,6 @@ class ExceptionExercisesTest extends FunSpec with TypeCheckedTripleEquals {
       assert(caught.getMessage === "provided name is empty")
     }
 
-    it("should throw an EmptyNameException if the name supplied contains only spaces") {
-      val caught = intercept[EmptyNameException] {
-        getName("          ")
-      }
-
-      assert(caught.getMessage === "provided name is empty")
-    }
   }
 
   describe("getAge") {

--- a/src/test/scala/fundamentals/level03/Exceptions2EitherExercisesTest.scala
+++ b/src/test/scala/fundamentals/level03/Exceptions2EitherExercisesTest.scala
@@ -16,9 +16,6 @@ class Exceptions2EitherExercisesTest extends FunSpec with TypeCheckedTripleEqual
       assert(getName("") === Left(EmptyName("provided name is empty")))
     }
 
-    it("should return an EmptyName if the name supplied contains only spaces") {
-      assert(getName("          ") === Left(EmptyName("provided name is empty")))
-    }
   }
 
   describe("getAge") {


### PR DESCRIPTION
I don't care about trimming in OptionExercises.

Let's keep this minimal. I don't think having to trim the String is important to the lesson here.