### PR TITLE
Change getUnknowns exercise to getErrors so it can be re-used later.

### DIFF
--- a/src/main/scala/fundamentals/level04/LogParser.scala
+++ b/src/main/scala/fundamentals/level04/LogParser.scala
@@ -77,7 +77,7 @@ object LogParser {
   /**
     * Define a function that returns only logs that are errors
     *
-    * scala> getUnknowns(List(KnownLog(Error(2), 123, some error msg"), UnknownLog("blblbaaaaa")))
+    * scala> getErrors(List(KnownLog(Error(2), 123, some error msg"), UnknownLog("blblbaaaaa")))
     * = List(KnownLog(Error(2), 123, some error msg"))
     **/
   def getErrors(logs: List[LogMessage]): List[LogMessage] = ???

--- a/src/main/scala/fundamentals/level04/LogParser.scala
+++ b/src/main/scala/fundamentals/level04/LogParser.scala
@@ -75,12 +75,12 @@ object LogParser {
   def parseLogFile(fileContent: String): List[LogMessage] = ???
 
   /**
-    * Define a function that returns only logs that are unknown
+    * Define a function that returns only logs that are errors
     *
-    * scala> getUnknowns(List(KnownLog(Info, 147, "mice in the air"), UnknownLog("blblbaaaaa")))
-    * = List(UnknownLog("blblbaaaaa"))
+    * scala> getUnknowns(List(KnownLog(Error(2), 123, some error msg"), UnknownLog("blblbaaaaa")))
+    * = List(KnownLog(Error(2), 123, some error msg"))
     **/
-  def getUnknowns(logs: List[LogMessage]): List[LogMessage] = ???
+  def getErrors(logs: List[LogMessage]): List[LogMessage] = ???
  
   /**
     * Write a function to convert a `LogMessage` to a readable `String`.
@@ -104,7 +104,7 @@ object LogParser {
     * scala> showErrorsOverSeverity(logFile, 2)
     * = List("Error 5 (158) some strange error")
     *
-    * Hint: Use `parseLogFile` and `showLogMessage`
+    * Hint: Use `parseLogFile`, `getErrors` and `showLogMessage`
     **/
   def showErrorsOverSeverity(fileContent: String, severity: Int): List[String] = ???
 

--- a/src/main/scala/fundamentals/level04/LogParser.scala
+++ b/src/main/scala/fundamentals/level04/LogParser.scala
@@ -75,12 +75,16 @@ object LogParser {
   def parseLogFile(fileContent: String): List[LogMessage] = ???
 
   /**
-    * Define a function that returns only logs that are errors
+    * Define a function that returns only logs that are errors over the given severity level.
+    * It should not return any log that is not an error.
     *
-    * scala> getErrors(List(KnownLog(Error(2), 123, some error msg"), UnknownLog("blblbaaaaa")))
+    * scala> getErrorsOverSeverity(List(KnownLog(Error(2), 123, some error msg"), UnknownLog("blblbaaaaa")), 1)
     * = List(KnownLog(Error(2), 123, some error msg"))
+    *
+    * scala> getErrorsOverSeverity(List(KnownLog(Error(2), 123, some error msg")), 2)
+    * = List()
     **/
-  def getErrors(logs: List[LogMessage]): List[LogMessage] = ???
+  def getErrorsOverSeverity(logs: List[LogMessage], severity: Int): List[LogMessage] = ???
  
   /**
     * Write a function to convert a `LogMessage` to a readable `String`.
@@ -104,7 +108,7 @@ object LogParser {
     * scala> showErrorsOverSeverity(logFile, 2)
     * = List("Error 5 (158) some strange error")
     *
-    * Hint: Use `parseLogFile`, `getErrors` and `showLogMessage`
+    * Hint: Use `parseLogFile`, `getErrorsOverSeverity` and `showLogMessage`
     **/
   def showErrorsOverSeverity(fileContent: String, severity: Int): List[String] = ???
 

--- a/src/test/scala/fundamentals/level04/LogParserTest.scala
+++ b/src/test/scala/fundamentals/level04/LogParserTest.scala
@@ -36,16 +36,17 @@ class LogParserTest extends FunSpec with TypeCheckedTripleEquals {
 
   }
 
-  describe("getErrors") {
+  describe("getErrorsOverSeverity") {
 
-    it("should return the errors only") {
-      val errorLog = KnownLog(Error(2), 123, "some error msg")
+    it("should return the errors over severity level only") {
+      val errorLogUnderSeverity = KnownLog(Error(2), 123, "some error msg")
+      val errorLogOverSeverity = KnownLog(Error(3), 123, "some error msg")
       val unknown1 = UnknownLog("X blblbaaaaa")
       val unknown2 = UnknownLog("W foo")
 
-      val errorsOnly = getErrors(List(errorLog, unknown1, unknown2))
+      val errorsOnly = getErrorsOverSeverity(List(errorLogUnderSeverity, errorLogOverSeverity, unknown1, unknown2), 2)
 
-      assert(errorsOnly === List(errorLog))
+      assert(errorsOnly === List(errorLogOverSeverity))
     }
 
   }

--- a/src/test/scala/fundamentals/level04/LogParserTest.scala
+++ b/src/test/scala/fundamentals/level04/LogParserTest.scala
@@ -36,16 +36,16 @@ class LogParserTest extends FunSpec with TypeCheckedTripleEquals {
 
   }
 
-  describe("getUnknowns") {
+  describe("getErrors") {
 
-    it("should return the unknowns only") {
-      val known = KnownLog(Info, 147, "mice in the air")
+    it("should return the errors only") {
+      val errorLog = KnownLog(Error(2), 123, "some error msg")
       val unknown1 = UnknownLog("X blblbaaaaa")
       val unknown2 = UnknownLog("W foo")
 
-      val unknownsOnly = getUnknowns(List(known, unknown1, unknown2))
+      val errorsOnly = getErrors(List(errorLog, unknown1, unknown2))
 
-      assert(unknownsOnly === List(unknown1, unknown2))
+      assert(errorsOnly === List(errorLog))
     }
 
   }


### PR DESCRIPTION
While working through the exercises with someone during a coaching session, I found that it would give the exercise more purpose if it can be reused later on.

The `showErrorsOverSeverity` exercise can re-use `getErrors` now.

https://github.com/wjlow/intro-to-scala/issues/128