### PR TITLE
Add timestamp to warn log in logfile.csv

### DIFF
--- a/src/main/resources/logfile.csv
+++ b/src/main/resources/logfile.csv
@@ -1,4 +1,4 @@
 I,147,mice in the air
-W,could've been bad
+W,149,could've been bad
 E,5,158,some strange error
 E,2,148,istereadea


### PR DESCRIPTION
Not a big deal, but currently the WARN line in `logfile.csv` will probably be parsed as an `UnknownLog`.

https://github.com/wjlow/intro-to-scala/issues/125