### PR TITLE
fix incorrect test

### DIFF
--- a/src/test/scala/fundamentals/level01/IntroExercisesTest.scala
+++ b/src/test/scala/fundamentals/level01/IntroExercisesTest.scala
@@ -16,16 +16,16 @@ class IntroExercisesTest extends FunSpec with TypeCheckedTripleEquals {
 
   describe("foo") {
 
-    it("foo can only return the parameter unmodified (aka the 'identity' function)") {
+    it("can only return the parameter unmodified (aka the 'identity' function)") {
       assert(foo(1) === 1)
     }
 
-  }  
-  
+  }
+
   describe("bar") {
 
-    it("bar can be any Int") {
-      assert(foo(1).isInstanceOf[Int])
+    it("can be any Int") {
+      assert(bar(1).isInstanceOf[Int])
     }
 
   }


### PR DESCRIPTION
The **bar** test was using **foo**. Not sure how we missed this before. Also changed the names
of the tests a little so there was no repetition.

<img src="https://media.giphy.com/media/hn4G9CUUcr7RC/giphy.gif" width="100%" />