### PR TITLE
Removing showEveryNthPerson.

### DIFF
--- a/src/main/scala/fundamentals/level02/ListExercises.scala
+++ b/src/main/scala/fundamentals/level02/ListExercises.scala
@@ -166,31 +166,4 @@ object ListExercises {
     */
   def youngestPerson(persons: List[Person]): Person = ???
 
-  /**
-    * Typically in a data processing job, you would only want to log every
-    * 100th or 1000th iteration so you do not clog up the logs.
-    *
-    * scala> val persons = List(Person("Person1", 21), Person("Person2", 21), Person("Person3", 21), Person("Person4", 21))
-    * scala> showEveryNthPerson(2, persons)
-    * = List("Person2 is 21 years old", "Person4 is 21 years old")
-    *
-    * Hint: Use `zipWithIndex`, `filter` and `showPerson1`.
-    * `zipWithIndex` will give you a `List` of tuples.
-    * You can deconstruct them by pattern matching inside filter, e.g.
-    *
-    * ```
-    * List(("abc", 1), ("def", 2)).filter {
-    *   case (str, num) => // do something with `str` and `num`
-    * }
-    * ```
-    *
-    * Otherwise, you'll need to use `._1` and `._2` methods to access the fields in the tuple, e.g.
-    *
-    * ```
-    * List(("abc", 1), ("def", 2)).filter(pair => // do something with `pair._1` and `pair._2`)
-    * ```
-    *
-    */
-  def showEveryNthPerson(n: Int, persons: List[Person]): List[String] = ???
-
 }

--- a/src/test/scala/fundamentals/level02/ListExercisesTest.scala
+++ b/src/test/scala/fundamentals/level02/ListExercisesTest.scala
@@ -109,21 +109,4 @@ class ListExercisesTest extends FunSpec with TypeCheckedTripleEquals {
 
   }
 
-  describe("showEveryNthPerson") {
-
-    it("should return elements at index 1, 3 and 5") {
-      val p1 = Person("Person1", 21)
-      val p2 = Person("Person2", 21)
-      val p3 = Person("Person3", 21)
-      val p4 = Person("Person4", 21)
-      val p5 = Person("Person5", 21)
-      val p6 = Person("Person6", 21)
-      val p7 = Person("Person7", 21)
-      val persons = List(p1, p2, p3, p4, p5, p6, p7)
-
-      assert(showEveryNthPerson(2, persons) === List("Person2 is 21 years old", "Person4 is 21 years old", "Person6 is 21 years old"))
-    }
-
-  }
-
 }


### PR DESCRIPTION
Instead of teaching zipping, this ends up being an index-counting exercise. The test cases were also non-exhaustive and only covered the case where N=2. 

We should come up with a better exercise for zipping next time. For now, I reckon we remove this entirely.