### PR TITLE
Fix inaccurate listing spec description

### DIFF
--- a/src/test/scala/fundamentals/level02/ListExercisesTest.scala
+++ b/src/test/scala/fundamentals/level02/ListExercisesTest.scala
@@ -98,7 +98,7 @@ class ListExercisesTest extends FunSpec with TypeCheckedTripleEquals {
       assert(youngestPerson(Nil) === Person("Nobody", 0))
     }
 
-    it("should return person with the smallest age given non-empty List") {
+    it("should return the first person in the list with the smallest age given a non-empty List") {
       val bob = Person("Bob", 22)
       val sally = Person("Sally", 21)
       val jimmy = Person("Jimmy", 21)


### PR DESCRIPTION
Super minor, but got confused while doing this exercise because the description didn't match the expectation in the spec. Turns out the exercise text states that the first person in the list should be returned, but this isn't reflected in the spec description.