### PR TITLE
Update Java8 install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ Test if you have Java 8 already with `java -version`.
 ##### macOS (using [Homebrew](https://brew.sh))
 
 ```
-$ brew tap caskroom/versions
-$ brew cask install java8
+$ brew cask install caskroom/versions/adoptopenjdk8
 ```
 
 #### 3. Install [Docker](https://www.docker.com/)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Test if you have Java 8 already with `java -version`.
 ##### macOS (using [Homebrew](https://brew.sh))
 
 ```
+$ brew tap caskroom/versions
 $ brew cask install caskroom/versions/adoptopenjdk8
 ```
 


### PR DESCRIPTION
`java8` doesn't work anymore in `brew cask`: https://github.com/Homebrew/homebrew-cask/issues/58311

This fixes it using openjdk8