### PR TITLE
Made test more robust

### DIFF
--- a/src/test/scala/introcourse/level01/IntroExercisesTest.scala
+++ b/src/test/scala/introcourse/level01/IntroExercisesTest.scala
@@ -58,8 +58,8 @@ class IntroExercisesTest extends FunSpec with TypeCheckedTripleEquals {
 
   describe("timesTwoIfEven") {
 
-    it("given 2 returns 4") {
-      assert(timesTwoIfEven(2) === 4)
+    it("given 4 returns 8") {
+      assert(timesTwoIfEven(4) === 8)
     }
 
     it("given 3 returns 3") {


### PR DESCRIPTION
with 2, the implementation could use square rather than times 2 and still pass (1 of the peeps that tried this last week had an incorrectly implemented solution which passed the test)