### PR TITLE
Rename severity parameter to minimumSeverity

### DIFF
--- a/src/main/scala/introcourse/level07/LogParser.scala
+++ b/src/main/scala/introcourse/level07/LogParser.scala
@@ -105,7 +105,7 @@ object LogParser {
     * scala> getErrorsOverSeverity(List(KnownLog(Error(2), 123, some error msg")), 2)
     * = List()
     **/
-  def getErrorsOverSeverity(logs: List[LogMessage], severity: Int): List[LogMessage] = ???
+  def getErrorsOverSeverity(logs: List[LogMessage], minimumSeverity: Int): List[LogMessage] = ???
 
   /**
     * Write a function to convert a `LogMessage` to a readable `String`.


### PR DESCRIPTION
This is so when they pattern match on `case KnownLog(Error(severity..`, there is no conflicting variable name.