### PR TITLE
Add hints to `fst`, rename `fst` and `snd` to `first` and `second`.

### DIFF
--- a/src/main/scala/introcourse/level01/IntroExercises.scala
+++ b/src/main/scala/introcourse/level01/IntroExercises.scala
@@ -86,6 +86,11 @@ object IntroExercises {
 
   /**
     * How can we extract the first element of a pair?
+    *
+    * Hint 1: Check the getters on `pair`.
+    * Hint 2: Read up on pattern matching on tuples.
+    *
+    * https://docs.scala-lang.org/tour/tuples.html
     */
   def fst(pair: (String, Int)): String = ???
 

--- a/src/main/scala/introcourse/level01/IntroExercises.scala
+++ b/src/main/scala/introcourse/level01/IntroExercises.scala
@@ -92,11 +92,11 @@ object IntroExercises {
     *
     * https://docs.scala-lang.org/tour/tuples.html
     */
-  def fst(pair: (String, Int)): String = ???
+  def first(pair: (String, Int)): String = ???
 
   /**
     * How can we extract the second element of a pair?
     */
-  def snd(pair: (String, Int)): Int = ???
+  def second(pair: (String, Int)): Int = ???
 
 }

--- a/src/test/scala/introcourse/level01/IntroExercisesTest.scala
+++ b/src/test/scala/introcourse/level01/IntroExercisesTest.scala
@@ -89,22 +89,22 @@ class IntroExercisesTest extends FunSpec with TypeCheckedTripleEquals {
   describe("fst") {
 
     it("Jimmy and 25") {
-      assert(fst("Jimmy", 25) === "Jimmy")
+      assert(first("Jimmy", 25) === "Jimmy")
     }
 
     it("Sammy and 30") {
-      assert(fst("Sammy", 30) === "Sammy")
+      assert(first("Sammy", 30) === "Sammy")
     }
   }
 
   describe("snd") {
 
     it("Jimmy and 25") {
-      assert(snd("Jimmy", 25) === 25)
+      assert(second("Jimmy", 25) === 25)
     }
 
     it("Sammy and 30") {
-      assert(snd("Sammy", 30) === 30)
+      assert(second("Sammy", 30) === 30)
     }
   }
 


### PR DESCRIPTION
These hints should help the instructors to remember to cover both the getters and the pattern matching syntax.