### PR TITLE
Removed backtick style quotes around test for bob in a string.

### DIFF
--- a/src/test/scala/introcourse/level04/OptionExercises1Test.scala
+++ b/src/test/scala/introcourse/level04/OptionExercises1Test.scala
@@ -45,7 +45,7 @@ class OptionExercises1Test extends FunSpec with TypeCheckedTripleEquals {
     }
 
     it("should show invalid traffic light") {
-      assert(mkTrafficLightThenShow("bob") === "Traffic light `bob` is invalid")
+      assert(mkTrafficLightThenShow("bob") === "Traffic light bob is invalid")
     }
 
   }


### PR DESCRIPTION
Three people were trying to work out why their tests were failing but the 'bob' was placed in the string properly. The backticks just confused people.

This PR might break the solutions branch