### PR TITLE
Remove messages from error ADT

### DIFF
--- a/src/main/scala/introcourse/level05/EitherExercises.scala
+++ b/src/main/scala/introcourse/level05/EitherExercises.scala
@@ -11,11 +11,11 @@ object EitherExercises {
   //ADT for representing errors as values
   sealed trait AppError
 
-  case class EmptyName(message: String) extends AppError
+  case object EmptyName extends AppError
 
-  case class InvalidAgeValue(message: String) extends AppError
+  case class InvalidAgeValue(value: String) extends AppError
 
-  case class InvalidAgeRange(message: String) extends AppError
+  case class InvalidAgeRange(age: Int) extends AppError
 
   /**
     * In the ExceptionExercises exercise we used Exceptions to handle validation and
@@ -43,7 +43,6 @@ object EitherExercises {
     * case class Right[A](value: A) extends Either[Nothing, A]
     * case class Left[E](error: E) extends Either[E, Nothing]
     */
-
   /**
     * Implement the function getName, so that it returns a Left with an EmptyName if the name supplied
     * is empty or a Right if the supplied name is not empty.
@@ -52,7 +51,7 @@ object EitherExercises {
     * = Right(Fred)
     *
     * scala> getName("")
-    * = Left(EmptyName(provided name is empty))
+    * = Left(EmptyName)
     **/
   def getName(providedName: String): Either[AppError, String] = ???
 
@@ -65,10 +64,10 @@ object EitherExercises {
     * = Right(20)
     *
     * scala> getAge("Fred")
-    * = Left(InvalidAgeValue(provided age is invalid: Fred))
+    * = Left(InvalidAgeValue(Fred))
     *
     * scala> getAge("-1")
-    * = Left(InvalidAgeRange(provided age should be between 1-120: -1))
+    * = Left(InvalidAgeRange(-1))
     *
     * Hint: use the toInt method to convert a String to an Int.
     */
@@ -87,13 +86,13 @@ object EitherExercises {
     * = Right(Person(Fred,32))
     *
     * scala> createPerson("", "32")
-    * = Left(EmptyName(provided name is empty))
+    * = Left(EmptyName)
     *
     * scala> createPerson("Fred", "ThirtyTwo")
-    * = Left(InvalidAgeValue(provided age is invalid: ThirtyTwo))
+    * = Left(InvalidAgeValue(ThirtyTwo))
     *
     * scala> createPerson("Fred", "150")
-    * = Left(InvalidAgeRange(provided age should be between 1-120: 150))
+    * = Left(InvalidAgeRange(150))
     *
     * Hint: Use a for-comprehension to sequence the Eithers from getName and getAge
     */
@@ -109,13 +108,13 @@ object EitherExercises {
     * = Right(Person(FRED,32))
     *
     * scala> makeNameUpperCase("", "32")
-    * = Left(EmptyName(provided name is empty))
+    * = Left(EmptyName)
     *
     * scala> makeNameUpperCase("Fred", "ThirtyTwo")
-    * = Left(InvalidAgeValue(provided age is invalid: ThirtyTwo))
+    * = Left(InvalidAgeValue(ThirtyTwo))
     *
     * scala> makeNameUpperCase("Fred", "150")
-    * = Left(InvalidAgeRange(provided age should be between 1-120: 150))
+    * = Left(InvalidAgeRange(150))
     *
     * Hint: Use `createPerson` then use `map` and `copy`.
     *
@@ -123,6 +122,10 @@ object EitherExercises {
   def makeNameUpperCase(name: String, age: String): Either[AppError, Person] = ???
 
   /**
+    * When handling errors, you usually only want to handle them at a single point in your application. That error
+    * handler will interpret the AppError ADT into something that's more human readable. You could think of this
+    * function as the end of the world for our application, where we are providing feedback to the user on their input.
+    *
     * scala> createPersonAndShow("Fred", "32")
     * = "Fred is 32"
     *
@@ -130,10 +133,10 @@ object EitherExercises {
     * = "Empty name supplied"
     *
     * scala> createPersonAndShow("Fred", "ThirtyTwo")
-    * = "Invalid age value supplied"
+    * = "Invalid age value supplied: ThirtyTwo"
     *
     * scala> createPersonAndShow("Fred", "150")
-    * = "Invalid age range supplied"
+    * = "Provided age must be between 1-120: 150"
     *
     * Hint: Use `createPerson` then pattern match.
     *

--- a/src/test/scala/introcourse/level05/EitherExercisesTest.scala
+++ b/src/test/scala/introcourse/level05/EitherExercisesTest.scala
@@ -13,7 +13,7 @@ class EitherExercisesTest extends FunSpec with TypeCheckedTripleEquals {
     }
 
     it("should return an EmptyName if the name supplied is empty") {
-      assert(getName("") === Left(EmptyName("provided name is empty")))
+      assert(getName("") === Left(EmptyName))
     }
 
   }
@@ -25,15 +25,15 @@ class EitherExercisesTest extends FunSpec with TypeCheckedTripleEquals {
     }
 
     it("should return an InvalidAgeValue if the age supplied is not an Int") {
-      assert(getAge("Fred") === Left(InvalidAgeValue("provided age is invalid: Fred")))
+      assert(getAge("Fred") === Left(InvalidAgeValue("Fred")))
     }
 
     it("should return an InvalidAgeRange if the age supplied is not between 1 and 120") {
-      assert(getAge("-1") === Left(InvalidAgeRange("provided age should be between 1-120: -1")))
+      assert(getAge("-1") === Left(InvalidAgeRange(-1)))
     }
 
     it("should return an InvalidAgeRange if the age supplied is 0") {
-      assert(getAge("0") === Left(InvalidAgeRange("provided age should be between 1-120: 0")))
+      assert(getAge("0") === Left(InvalidAgeRange(0)))
     }
 
     it("should accept age of one") {
@@ -53,15 +53,15 @@ class EitherExercisesTest extends FunSpec with TypeCheckedTripleEquals {
     }
 
     it("should return an EmptyName if the name supplied is empty") {
-      assert(createPerson("", "32") === Left(EmptyName("provided name is empty")))
+      assert(createPerson("", "32") === Left(EmptyName))
     }
 
     it("should return an InvalidAgeValue if the age supplied is not an Int") {
-      assert(createPerson("Fred", "ThirtyTwo") === Left(InvalidAgeValue("provided age is invalid: ThirtyTwo")))
+      assert(createPerson("Fred", "ThirtyTwo") === Left(InvalidAgeValue("ThirtyTwo")))
     }
 
     it("should return an InvalidAgeRange if the age supplied is not between 1 and 120") {
-      assert(createPerson("Fred", "150") === Left(InvalidAgeRange("provided age should be between 1-120: 150")))
+      assert(createPerson("Fred", "150") === Left(InvalidAgeRange(150)))
     }
   }
 
@@ -72,15 +72,15 @@ class EitherExercisesTest extends FunSpec with TypeCheckedTripleEquals {
     }
 
     it("should return an EmptyName if the name supplied is empty") {
-      assert(createPerson2("", "32") === Left(EmptyName("provided name is empty")))
+      assert(createPerson2("", "32") === Left(EmptyName))
     }
 
     it("should return an InvalidAgeValue if the age supplied is not an Int") {
-      assert(createPerson2("Fred", "ThirtyTwo") === Left(InvalidAgeValue("provided age is invalid: ThirtyTwo")))
+      assert(createPerson2("Fred", "ThirtyTwo") === Left(InvalidAgeValue("ThirtyTwo")))
     }
 
     it("should return an InvalidAgeRange if the age supplied is not between 1 and 120") {
-      assert(createPerson2("Fred", "150") === Left(InvalidAgeRange("provided age should be between 1-120: 150")))
+      assert(createPerson2("Fred", "150") === Left(InvalidAgeRange(150)))
     }
   }
 
@@ -95,11 +95,11 @@ class EitherExercisesTest extends FunSpec with TypeCheckedTripleEquals {
     }
 
     it("should show an invalid age value") {
-      assert(createPersonAndShow("Fred", "ThirtyTwo") === "Invalid age value supplied")
+      assert(createPersonAndShow("Fred", "ThirtyTwo") === "Invalid age value supplied: ThirtyTwo")
     }
 
     it("should show an invalid age range") {
-      assert(createPersonAndShow("Fred", "150") === "Invalid age range supplied")
+      assert(createPersonAndShow("Fred", "150") === "Provided age must be between 1-120: 150")
     }
 
   }
@@ -111,15 +111,15 @@ class EitherExercisesTest extends FunSpec with TypeCheckedTripleEquals {
     }
 
     it("should show an invalid name") {
-      assert(makeNameUpperCase("", "32") === Left(EmptyName("provided name is empty")))
+      assert(makeNameUpperCase("", "32") === Left(EmptyName))
     }
 
     it("should show an invalid age value") {
-      assert(makeNameUpperCase("Fred", "ThirtyTwo") === Left(InvalidAgeValue("provided age is invalid: ThirtyTwo")))
+      assert(makeNameUpperCase("Fred", "ThirtyTwo") === Left(InvalidAgeValue("ThirtyTwo")))
     }
 
     it("should show an invalid age range") {
-      assert(makeNameUpperCase("Fred", "150") === Left(InvalidAgeRange("provided age should be between 1-120: 150")))
+      assert(makeNameUpperCase("Fred", "150") === Left(InvalidAgeRange(150)))
     }
   }
 
@@ -133,10 +133,10 @@ class EitherExercisesTest extends FunSpec with TypeCheckedTripleEquals {
   describe("collectErrors") {
 
     it("should return a List of errors returned while processing inputs") {
-      assert(collectErrors === List(InvalidAgeValue("provided age is invalid: 5o"),
-                                    InvalidAgeRange("provided age should be between 1-120: 200"),
-                                    InvalidAgeRange("provided age should be between 1-120: 0"),
-                                    EmptyName("provided name is empty")))
+      assert(collectErrors === List(InvalidAgeValue("5o"),
+                                    InvalidAgeRange(200),
+                                    InvalidAgeRange(0),
+                                    EmptyName))
     }
   }
 }


### PR DESCRIPTION
I've been thinking about this exercise [exercise](https://github.com/wjlow/intro-to-scala/blob/master/src/main/scala/introcourse/level05/EitherExercises.scala#L149), where it feels like you're almost repeating the message from the error itself. Leads to some students wondering why we have to retype the message, instead of trying to extract it from the error somehow. 

📦 
- This change makes it so only the invalid value itself is contained in the error
- Leave interpreting the error to the createPersonAndShow function
