### PR TITLE
Remove the thought exercise for "mean".

### DIFF
--- a/src/main/scala/introcourse/level04/NullExercises.scala
+++ b/src/main/scala/introcourse/level04/NullExercises.scala
@@ -91,10 +91,5 @@ object NullExercises {
   def mkPersonOrNullThenChangeName(oldName: String, age: Int, newName: String): Person = ???
 
   def changeName(newName: String, person: Person): Person = person.copy(name = newName)
-
-  /**
-    * Thought exercise: Does the following function return a `null`?
-    */
-  def mean(nums: List[Int]): Double = ???
-
+ 
 }


### PR DESCRIPTION
It's weird and awkward and unnecessary.