### PR TITLE
Import the constructors of the ADTs that learners will define in this exercise

### DIFF
--- a/src/test/scala/introcourse/level07/LogParserTest.scala
+++ b/src/test/scala/introcourse/level07/LogParserTest.scala
@@ -1,6 +1,8 @@
 package introcourse.level07
 
 import introcourse.level07.LogParser.*
+import introcourse.level07.LogParser.LogLevel.*
+import introcourse.level07.LogParser.LogMessage.*
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.funspec.AnyFunSpec
 


### PR DESCRIPTION
This is so that they can simply remove the `Types.*` import and things will still compile.

With the change from sealed traits to enums, the namespacing of the constructors changed.